### PR TITLE
Fix typo in reflection error message

### DIFF
--- a/equiavia.components.Utilities/ClassIntrospectExtensions.cs
+++ b/equiavia.components.Utilities/ClassIntrospectExtensions.cs
@@ -65,7 +65,7 @@ namespace equiavia.components.Utilities
             }
             else
             {
-                Console.WriteLine(obj.GetType().Name + "does not have a propoerty called " + name + ". Could not set the value.");
+                Console.WriteLine(obj.GetType().Name + "does not have a property called " + name + ". Could not set the value.");
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix spelling of `property` in ClassIntrospectExtensions error message

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f8f7ae608320b8f5dc58acc315bf